### PR TITLE
Meta with Config

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Router, Event, NavigationEnd, NavigationError } from '@angular/router';
+import { MetaService } from './services/meta.service';
 
 @Component({
   selector: 'app-root',
@@ -6,7 +8,18 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent implements OnInit {
-  constructor() {}
+  constructor(private router: Router, private metaService: MetaService) {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    // this.router.events
+    //   .pipe(filter(event) => event instanceof NavigationEnd),
+    //   pluck('urlAfterRedirects'),
+    //   tap((data:string) => this.metaService.updateMeta(data));
+    this.router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationEnd) {
+        console.log(event.url);
+        this.metaService.updateMeta(event.url);
+      }
+    });
+  }
 }

--- a/src/app/services/meta.config.ts
+++ b/src/app/services/meta.config.ts
@@ -1,0 +1,14 @@
+export const META_INFO: any = {
+  '/': {
+    title: 'This is the app root',
+    description: 'Welcome to my app',
+  },
+  '/home': {
+    title: 'This is the homepage',
+    description: 'Welcome to the homepage',
+  },
+  '/contact': {
+    title: 'Contact us',
+    description: 'Setting meta for the contact page',
+  },
+};

--- a/src/app/services/meta.service.spec.ts
+++ b/src/app/services/meta.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MetaService } from './meta.service';
+
+describe('MetaService', () => {
+  let service: MetaService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MetaService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/meta.service.ts
+++ b/src/app/services/meta.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+import { META_INFO } from './meta.config';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MetaService {
+  constructor(private title: Title, private meta: Meta) {}
+
+  updateMeta(route: string) {
+    if (Object.prototype.hasOwnProperty.call(META_INFO, route)) {
+      const { title, description } = META_INFO[route];
+      this.updateTitle(title);
+      this.updateDescription(description);
+    }
+  }
+
+  updateTitle(title: string) {
+    if (title) {
+      this.title.setTitle(title);
+    }
+  }
+
+  updateDescription(description: string) {
+    if (description) {
+      this.meta.updateTag({ name: 'description', content: description });
+    }
+  }
+}


### PR DESCRIPTION
**Additions:** Using a config file to set the title and meta description of a way. Confirmed that it does pretender when viewing the page source.

**Next Steps:** Populate the config dynamically with content from the CMS with one of the two options below

1. Via API from a CMS
2. External source -> CDN
3. Dynamic file creation on publish of CMS with a webhook call to service